### PR TITLE
Set default value for Radio editors on schema

### DIFF
--- a/src/editors/radio.coffee
+++ b/src/editors/radio.coffee
@@ -35,6 +35,10 @@ Form.editors.Radio = Form.editors.Select.extend({
   getValue: ->
     @$('input[type=radio]:checked').val()
   setValue: (value) ->
+    # Set a default value if defined on the schema.
+    if not value? and @schema.default?
+      value = @schema.default
+
     @value = value
     @$('input[type=radio]').val [ value ]
     return


### PR DESCRIPTION
Previously, a default value could only be set via the `data` property.
This patch allows a default value to be specified directly on `schema`
via `schema.default`.

Closes #14 